### PR TITLE
Add missing method db.all('Users') from the API into the Documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ db.forEach('Users', user => console.log(user.name))
 db.filter('Users', user => user.isAdmin)
 ```
 
+### all
+```js
+db.all('Users')
+```
+
 ### getMany
 ```js
 db.getMany('Users', ['key 1', 'key 2', 'key 3'])


### PR DESCRIPTION
I'm using the plugin in one of my aerojs projects and I couldn't found a method to retrieve all the entries in a Set in the documentation so I searched in Database.js and found this block of code at line 116: 
```js
this.all = (set, func) => {
	let records = []
	return this.forEach(set, record => records.push(record)).then(() => records)
}
```
I then tough that this method was forgotten when the documentation was written.